### PR TITLE
Start uWSGI after synced folder mounts

### DIFF
--- a/puppet/modules/uwsgi/manifests/init.pp
+++ b/puppet/modules/uwsgi/manifests/init.pp
@@ -1,5 +1,7 @@
 class uwsgi {
 
+    $mount_point = "/var/www/${hostname}.${domain}/src"
+
     $params = {
         "uid" => "www-data",
         "gid" => "www-data",
@@ -10,7 +12,7 @@ class uwsgi {
         "master" => "",
         "die-on-term" => "",
         "logto" => "/var/log/uwsgi.log",
-        "chdir" => "/var/www/${hostname}.${domain}/src",
+        "chdir" => $mount_point,
         "module" => "app",
         "callable" => "app",
     }

--- a/puppet/modules/uwsgi/templates/uwsgi.conf.erb
+++ b/puppet/modules/uwsgi/templates/uwsgi.conf.erb
@@ -1,7 +1,7 @@
 # Emperor uWSGI script
 
 description "uWSGI Emperor"
-start on runlevel [2345]
+start on vagrant-mounted MOUNTPOINT=<%= @mount_point %>
 stop on runlevel [06]
 
 exec /usr/local/bin/uwsgi <% @params.each_pair do | param, val | %> --<%= param %> <%= val %> <% end %>


### PR DESCRIPTION
It looks like #9 is caused by the synced folders not being mounted at the time the upstart init script runs. uWSGI can't find the flask app and errors out. I've changed the 'start on' for the init from the vagrant box booting up to waiting for the appropriate mounting signal. I'm new to both puppet and github, so any feedback would be appreciated.
